### PR TITLE
Expose Promise to user

### DIFF
--- a/lib/cucumberjs/world.js
+++ b/lib/cucumberjs/world.js
@@ -4,7 +4,8 @@ var chai           = require('chai'),
     fs             = require('fs'),
     path           = require('path'),
     log            = require('../log'),
-    widgets        = require('chimp-widgets');
+    widgets        = require('chimp-widgets'),
+    Promise        = require('bluebird');
 
 chai.use(chaiAsPromised);
 chai.should();
@@ -15,6 +16,9 @@ module.exports = function () {
   global.chai = chai;
   global.expect = chai.expect;
   global.assert = chai.assert;
+
+  // Give the user access to Promise functions. E.g. Promise.all.
+  global.Promise = Promise;
 
   if (process.env['chimp.ddp']) {
     log.debug('[chimp][world] creating DDP connection');


### PR DESCRIPTION
Gives the user access to Promise functions.
E.g. Promise.all for multiple promise assertions.