### PR TITLE
Fixes checks against boolean environment variables

### DIFF
--- a/bin/chimp
+++ b/bin/chimp
@@ -22,7 +22,9 @@ var argv = minimist(process.argv, {
     'waitForTimeout': 10000,
     'screenshotsOnError': true,
     'screenshotsPath': '.',
-    'serverHost': 'localhost'
+    'serverHost': 'localhost',
+    'server': false,
+    'noSessionReuse': false
   },
   'boolean': true
 });

--- a/lib/chimp.js
+++ b/lib/chimp.js
@@ -50,6 +50,7 @@ function Chimp (options) {
 
   // store all cli parameters in env hash
   for (var option in options) {
+    // Note: Environment variables are always strings.
     process.env['chimp.' + option] = options[option];
   }
 

--- a/lib/cucumberjs/hooks.js
+++ b/lib/cucumberjs/hooks.js
@@ -159,7 +159,7 @@ module.exports = function () {
    */
   this.StepResult(function (event, callback) {
     var stepResult = event.getPayloadItem('stepResult');
-    if (process.env['chimp.screenshotsOnError'] && !stepResult.isSuccessful()) {
+    if (process.env['chimp.screenshotsOnError'] !== 'false' && !stepResult.isSuccessful()) {
       log.debug('[chimp][hooks] step failed - capturing screenshot');
       global.browser.capture('step_failed', callback);
     } else {

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -55,13 +55,13 @@ SessionManager.prototype.remote = function (webdriverOptions, callback) {
       return;
     }
 
-    if (!!process.env['chimp.noSessionReuse']) {
+    if (process.env['chimp.noSessionReuse'] !== 'false') {
       log.debug('[chimp][session-manager] noSessionReuse is true, not reusing a session');
       callback(null, browser);
       return;
     }
 
-    if (!process.env['chimp.watch'] && !process.env['chimp.server']) {
+    if (process.env['chimp.watch'] === 'false' && process.env['chimp.server'] === 'false') {
       log.debug('[chimp][session-manager] watch mode is false, not reusing a session');
       callback(null, browser);
       return;

--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -55,7 +55,7 @@ SessionManager.prototype.remote = function (webdriverOptions, callback) {
       return;
     }
 
-    if (process.env['chimp.noSessionReuse'] !== 'false') {
+    if (process.env['chimp.noSessionReuse'] && process.env['chimp.noSessionReuse'] !== 'false') {
       log.debug('[chimp][session-manager] noSessionReuse is true, not reusing a session');
       callback(null, browser);
       return;


### PR DESCRIPTION
Environment variables are always strings.
So the correct check is `process.env.foo !== 'false'` to check for true.
The convention is that everything else but 'false' is true.