### PR TITLE
Enable screenshots on error only for PhantomJS by default

### DIFF
--- a/bin/chimp
+++ b/bin/chimp
@@ -20,7 +20,7 @@ var argv = minimist(process.argv, {
     'watchTags': '@dev',
     'timeoutsAsyncScript': 10000,
     'waitForTimeout': 10000,
-    'screenshotsOnError': true,
+    'screenshotsOnError': null,
     'screenshotsPath': '.',
     'serverHost': 'localhost',
     'server': false,
@@ -31,6 +31,13 @@ var argv = minimist(process.argv, {
 
 if (argv.deviceName) {
   argv.browser = '';
+}
+
+if (argv.screenshotsOnError === null) {
+  // For Chrome taking screenshots will focus the browser (haven't tested it with other browsers).
+  // For this reason we only enable screenshots for phantomjs by default.
+  // Because in phantomjs you don't get visual feedback from the browser directly when you develop.
+  argv.screenshotsOnError = (argv.browser === 'phantomjs');
 }
 
 try {


### PR DESCRIPTION
For Chrome taking screenshots will focus the browser (haven't tested it with other browsers).
For this reason we only enable screenshots for phantomjs by default.
Because in phantomjs you don't get visual feedback from the browser directly when you develop.