### PR TITLE
Fixes invalid attempt to kill selenium when using sauce labs

### DIFF
--- a/lib/session-manager.js
+++ b/lib/session-manager.js
@@ -205,7 +205,7 @@ SessionManager.prototype.killCurrentSession = function (callback) {
     return;
   }
 
-  if (!process.env['chimp.noSessionReuse']) {
+  if (process.env['chimp.noSessionReuse']) {
     log.debug('[chimp][session-manager] noSessionReuse is true, , not killing session');
     callback();
     return;
@@ -223,7 +223,7 @@ SessionManager.prototype.killCurrentSession = function (callback) {
 
   this._getWebdriverSessions(function(err, sessions) {
 
-    if (sessions.length) {
+    if (err === null && sessions.length) {
       // XXX this currently only works for one open session at a time
       var sessionId = sessions[0].id;
 


### PR DESCRIPTION
When using sauce labs as a provider, there is no need to kill the
selenium session.  Session manager now checks the noSessionReuse env
variable correctly and will also check that no error was returned when
getting the session list before attempting to kill the session.