### PR TITLE
Restricts logging to whitelisted ENVs during debug mode

### DIFF
--- a/meteor/src/mirror-server.js
+++ b/meteor/src/mirror-server.js
@@ -15,6 +15,24 @@ DEBUG = !!process.env.VELOCITY_DEBUG;
 
   var FRAMEWORK_NAME = 'cucumber';
   var WATCH_TAG = '@dev,@watch,@focus';
+  var ENV_WHITELIST = [
+    'CAPTURE_ALL_STEP_SCREENSHOTS','CHAI','CHIMP_ASYNC',
+    'CHIMP_DEBUG','CHIMP_OFFLINE','CHIMP_OPTIONS',
+    'CHIMP_NODE_OPTIONS','CUCUMBER','CUCUMBER_COFFEE_SNIPPETS',
+    'CUCUMBER_FORMAT','CUCUMBER_JSON_OUTPUT','CUCUMBER_NODES',
+    'CUCUMBER_SCREENSHOTS_DIR','CUCUMBER_SERVER_PORT','CUCUMBER_TAGS',
+    'CUCUMBER_TAIL','DEBUG','DEBUG_BRK_CUCUMBER','DEBUG_CUCUMBER',
+    'FRAMEWORK','HANDSHAKE','HOST',
+    'HTTP_FORWARDED_COUNT','HUB_HOST','HUB_PLATFORM',
+    'HUB_PORT','HUB_USER','HUB_VERSION',
+    'INSTALL_DEPENDENCIES','IS_MIRROR','METEOR_PRINT_ON_LISTEN',
+    'MIRROR_PORT','MOBILE_DDP_URL','NODE_ENV',
+    'PARENT_URL','PORT','PWD',
+    'ROOT_URL','SAVE_SCREENSHOTS','SCREENSHOTS_ON_ERROR',
+    'SELENIUM_BROWSER','TMPDIR','VELOCITY',
+    'VELOCITY_CI','VELOCITY_DEBUG','VELOCITY_MAIN_APP_PATH',
+    'WD_TIMEOUT_ASYNC_SCRIPT'
+  ];
   var BINARY = process.env.CHIMP_PATH || Npm.require('chimp').bin;
   if (
     process.env.NODE_ENV !== 'development' || !process.env.IS_MIRROR ||
@@ -252,7 +270,7 @@ DEBUG = !!process.env.VELOCITY_DEBUG;
       fs.chmodSync(BINARY, parseInt('555', 8));
       var nodePath = process.execPath;
       var nodeDir = path.dirname(nodePath);
-      var env = _.clone(process.env);
+      var env = _.pick(_.clone(process.env), ENV_WHITELIST);
       // Expose the Meteor node binary path for the script that is run
       env.PATH = nodeDir + ':' + env.PATH;
       var spawnOptions = {


### PR DESCRIPTION
Fixes a security issue where previously all ENVs would be logged during debug mode, potentially exposing sensitive data. This fix introduces a whitelist and uses Underscore pick to filter the process.env object.