### PR TITLE
Report branch to Simian

### DIFF
--- a/bin/chimp
+++ b/bin/chimp
@@ -30,6 +30,7 @@ var argv = minimist(process.argv, {
     'noSessionReuse': false,
     'simianResultEndPoint': 'api.simian.io/v1.0/result',
     'simianAccessToken': false,
+    'simianResultBranch': null,
     'sync': true,
     'mochaTimeout': 60000,
     'mochaReporter': 'spec'

--- a/lib/chimp.js
+++ b/lib/chimp.js
@@ -68,6 +68,13 @@ function Chimp (options) {
 Chimp.prototype.init = function (callback) {
   var self = this;
 
+  try {
+    this._initSimianResultBranch();
+  } catch (error) {
+    callback(error);
+    return;
+  }
+
   if (!this.fs.existsSync(path.resolve('.', 'package.json'))) {
     log.debug('[chimp] Did not find package.json, not running npm install');
     self.selectMode(callback);
@@ -93,6 +100,36 @@ Chimp.prototype.init = function (callback) {
     }
   });
 };
+
+Chimp.prototype._initSimianResultBranch = function () {
+  // Automatically set the result branch for the common CI tools
+  if (this.options.simianAccessToken &&
+    this.options.simianResultBranch === null
+  ) {
+    if (process.env.CI_BRANCH) {
+      // Codeship or custom
+      this.options.simianResultBranch = process.env.CI_BRANCH;
+    } else if (process.env.CIRCLE_BRANCH) {
+      // CircleCI
+      this.options.simianResultBranch = process.env.CIRCLE_BRANCH;
+    } else if (process.env.TRAVIS_BRANCH) {
+      // TravisCI
+      if (process.env.TRAVIS_PULL_REQUEST === 'false') {
+        this.options.simianResultBranch = process.env.TRAVIS_BRANCH;
+      } else {
+        // Ignore the builds that simulate the pull request merge,
+        // because the branch will be the target branch.
+        this.options.simianResultBranch = false;
+      }
+    } else {
+      throw new Error(
+        'You have not specified the branch that should be reported to Simian!' +
+        ' Do this with the --simianResultBranch argument' +
+        ' or the CI_BRANCH environment variable.'
+      )
+    }
+  }
+}
 
 /**
  * Decides which mode to run and kicks it off
@@ -316,7 +353,9 @@ Chimp.prototype.run = function (callback) {
         log.debug('[chimp] run complete');
       }
 
-      if (self.options.simianAccessToken) {
+      if (self.options.simianAccessToken &&
+        self.options.simianResultBranch !== false
+      ) {
         var simianReporter = new exports.SimianReporter(self.options);
         simianReporter.report(res, function () {
           callback(err, res);

--- a/lib/simian-reporter.js
+++ b/lib/simian-reporter.js
@@ -35,6 +35,7 @@ SimianReporter.prototype.report = function (result, callback) {
     json: true,
     body: {
       type: 'cucumber',
+      branch: this.options.simianResultBranch,
       result: JSON.parse(result[1][1])
     }
   }, function (error, response, body) {


### PR DESCRIPTION
Tested manually. Determines branch on Codeship, CircleCI and TravisCI automatically. We maybe can add support for more CI tools. When the user forgets to specify the branch, he gets a nice error message that tells him what he needs to do.

Before we release this, we need to merge and release the Simian branch for this feature.