### PR TITLE
fixed fs.access error by changing dependencies selenium-standalone pa…

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "request": "2.62.0",
     "requestretry": "1.5.0",
     "saucelabs": "~0.1.1",
-    "selenium-standalone": "^4.6.1",
+    "selenium-standalone": "4.7.1",
     "underscore": "~1.8.3",
     "xolvio-sync-webdriverio": "git://github.com/lgandecki/sync-webdriverio.git#multidriver", 
     "xolvio-jasmine-expect": "^1.0.0"


### PR DESCRIPTION
…ckage to using version 4.7.1

Chimp installs new version of selenium-standalone package version 4.8.0 and when we run tests we get an error:

[xolvio:cucumber] Bad response from Chimp server. { [Error: failed [500] {"statusCode":500,"error":"Internal Server Error","message":"An internal server error occurred"}] stack: [Getter] }
Debug: internal, implementation, error
    TypeError: Uncaught error: Object #<Object> has no method 'access'
    at chmodChromeDr (/Users/lucetius/Code/chimp/node_modules/selenium-standalone/lib/install.js:248:6)


The installed version uses fs.access that is avalible in node >= 0.12

Changing version to 4.7.1 fixes the problem