### PR TITLE
Changed chimp helper to configure the widget driver after loading the browser

### DIFF
--- a/lib/chimp-helper.js
+++ b/lib/chimp-helper.js
@@ -50,7 +50,6 @@ var chimpHelper = {
 
   configureWidgets: function () {
     // CHIMP WIDGETS
-    widgets.driver.api = global.browser;
     global.chimpWidgets = widgets;
   },
 
@@ -212,10 +211,15 @@ var chimpHelper = {
       }
     };
 
+    var configureChimpWidgetsDriver = function() {
+      widgets.driver.api = global.browser;
+    };
+
     try {
       setupBrowser();
       initBrowser();
       setupDdp();
+      configureChimpWidgetsDriver();
     } catch (error) {
       log.error('[chimp][helper] setupBrowserAndDDP had error');
       log.error(error);


### PR DESCRIPTION
Current chimp widgets is loaded before the browser is setup, meaning it meaning that it never actually receives the `global.browser` object as a driver. This PR simply moves the step that sets up chimp widget's default driver to be after the browser is setup.