### PR TITLE
Support BrowserStack local testing

### DIFF
--- a/bin/chimp
+++ b/bin/chimp
@@ -38,6 +38,7 @@ var argv = minimist(process.argv, {
     'simianRepositoryId': null,
     'sync': true,
     'tunnelIdentifier' : null,
+    'browserstackLocal': null,
     'mochaTimeout': 60000,
     'mochaReporter': 'spec',
     'mochaSlow' : 10000,

--- a/lib/chimp-helper.js
+++ b/lib/chimp-helper.js
@@ -130,6 +130,9 @@ var chimpHelper = {
         if(process.env['chimp.tunnelIdentifier']) {
           webdriverOptions.desiredCapabilities.tunnelIdentifier = process.env['chimp.tunnelIdentifier'];
           }
+        if (process.env['chimp.browserstackLocal']) {
+          webdriverOptions.desiredCapabilities['browserstack.local'] = process.env['chimp.browserstackLocal'];
+        }
         log.debug('[chimp][helper] webdriverOptions are ', JSON.stringify(webdriverOptions));
 
         var remoteSession = wrapAsync(global.sessionManager.remote, global.sessionManager);

--- a/lib/chimp-helper.js
+++ b/lib/chimp-helper.js
@@ -100,7 +100,8 @@ var chimpHelper = {
           desiredCapabilities: {
             browserName: process.env['chimp.browser'],
             platform: process.env['chimp.platform'],
-            name: process.env['chimp.name']
+            name: process.env['chimp.name'],
+            version: process.env['chimp.version']
           },
           user: process.env['chimp.user'] || process.env.SAUCE_USERNAME,
           key: process.env['chimp.key'] || process.env.SAUCE_ACCESS_KEY,


### PR DESCRIPTION
Adds a command line option to set the 'browserstack.local' capability 

(follows the same pattern as https://github.com/xolvio/chimp/commit/bb05237f09fd8bc68b1604c8180caf728e8283c9) 