### PR TITLE
switch from outdated phantomjs-bin to phantomjs-prebuilt

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "loglevel": "~1.4.0",
     "minimist": "~1.2.0",
     "mocha": "2.3.4",
-    "phantomjs-bin": "~1.0.1",
+    "phantomjs-prebuilt": "~2.1.4",
     "progress": "^1.1.8",
     "request": "2.67.0",
     "requestretry": "1.5.0",

--- a/src/lib/phantom.js
+++ b/src/lib/phantom.js
@@ -1,4 +1,4 @@
-var phantomjs     = require('phantomjs-bin'),
+var phantomjs     = require('phantomjs-prebuilt'),
     processHelper = require('./process-helper.js'),
     log           = require('./log');
 


### PR DESCRIPTION
phantomjs-bin package looks abandoned, it has plenty issues due to outdated phantomjs version (ignores localstorage file path configuration, breaks on hashes with repeated keys like {a:1, a:2}, does not show parse errors location, requires heap of polyfills etc etc) which is a pita. OTOH phantomjs-prebuilt is much more popular (14k downloads daily vs 300 in phantomjs-bin), tracks fresh phantomjs builds.