### PR TITLE
Fix appium compatibility issue

### DIFF
--- a/dist/lib/chimp-helper.js
+++ b/dist/lib/chimp-helper.js
@@ -162,7 +162,9 @@ var chimpHelper = {
         log.debug('[chimp][helper] saved screenshot to', ssPath);
       });
 
-      browser.timeoutsAsyncScriptSync(parseInt(process.env['chimp.timeoutsAsyncScript']));
+      if (parseInt(process.env['chimp.timeoutsAsyncScript']) > 0) {
+        browser.timeoutsAsyncScriptSync(parseInt(process.env['chimp.timeoutsAsyncScript']));
+      }
       log.debug('[chimp][helper] set timeoutsAsyncScript');
 
       if (process.env['chimp.browser'] === 'phantomjs') {


### PR DESCRIPTION
Appium for android does not support timeoutsAsyncScriptSync parameter yet, so now it will be optional. Passing -1 will not send it.