### PR TITLE
Add a hook for custom mocha-helpers

### DIFF
--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -23,17 +23,14 @@ var mocha = new Mocha(mochaOptions);
 
 mocha.addFile(path.join(path.resolve(__dirname, path.join('mocha-helper.js'))));
 
-var customMochaHelperPath = path.resolve(process.cwd(), process.env['chimp.path'], 'mocha-helper.js');
-
-if (fs.existsSync(customMochaHelperPath)) {
-  mocha.addFile(customMochaHelperPath);
-}
-
 // Add each .js file to the mocha instance
 var testDir = process.env['chimp.path'];
 glob.sync(path.join(testDir, '**')).filter(function (file) {
   // Only keep the .js files
   return file.substr(-3) === '.js';
+}).sort(function (file) {
+  // Include support files before anything elase
+  return file.includes('/support/') ? -1 : 0;
 }).forEach(function (file) {
   mocha.addFile(file);
 });

--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -23,6 +23,12 @@ var mocha = new Mocha(mochaOptions);
 
 mocha.addFile(path.join(path.resolve(__dirname, path.join('mocha-helper.js'))));
 
+var customMochaHelperPath = path.resolve(process.cwd(), process.env['chimp.path'], 'mocha-helper.js');
+
+if (fs.existsSync(customMochaHelperPath)) {
+  mocha.addFile(customMochaHelperPath);
+}
+
 // Add each .js file to the mocha instance
 var testDir = process.env['chimp.path'];
 glob.sync(path.join(testDir, '**')).filter(function (file) {


### PR DESCRIPTION
I found myself needing to create a custom mocha-helper in order to include some global befores / afters, and it seems like this is the best place to include it in Chimp. Drop a `mocha-helper.js` into the `features` directory and it's included before your tests, but after the Chimp `mocha-helper.js`.