### PR TITLE
Piped stdin to Mocha & Jasmine. Enables [ENTER] to continue.

### DIFF
--- a/src/lib/jasmine/jasmine.js
+++ b/src/lib/jasmine/jasmine.js
@@ -63,6 +63,7 @@ Jasmine.prototype.start = function (callback) {
 
   self.child = cp.fork(path.join(__dirname, 'jasmine-wrapper.js'), [], opts);
 
+  process.stdin.pipe(this.child.stdin);
   self.child.stdout.pipe(process.stdout);
   self.child.stderr.pipe(process.stderr);
 

--- a/src/lib/mocha/mocha.js
+++ b/src/lib/mocha/mocha.js
@@ -65,6 +65,7 @@ Mocha.prototype.start = function (callback) {
     '--color'
   ], opts);
 
+  process.stdin.pipe(this.child.stdin);
   self.child.stdout.pipe(process.stdout);
   self.child.stderr.pipe(process.stderr);
 


### PR DESCRIPTION
Hi, I put in a couple of small fixes for mocha and jasmine to enable [ENTER] to continue.  I verified that the new code works for mocha on my machine.

This resolves #351.

**BUT ...**
I did not test jasmine.
I ran `npm run testonly`:
1. It failed 2 tests in options loader because I am running on a windows 10 machine and the file path compares had trouble with `\` vs `/`. 
2. The tests seem to hang after `PASS  src\__tests__\session-factory-spec.js (0.428s)`

Am I correct in assuming this is a windows problem?
Maybe you can run the tests and verify that they all pass?  And also verify that Jasmine works?

Thanks!

**Update**: I see that the acceptance tests are automatically run, nice!