### PR TITLE
Integrate setup/teardown hooks for WebDriverIO, Jasmine and Mocha

### DIFF
--- a/src/lib/chimp-helper.js
+++ b/src/lib/chimp-helper.js
@@ -15,7 +15,6 @@ var chai            = require('chai'),
     exit            = require('exit'),
     booleanHelper   = require('./boolean-helper');
 import merge from 'deep-extend';
-import runHook from './utils/run-hook';
 import {
   parseNullableString,
   parseNullableInteger,
@@ -135,8 +134,6 @@ var chimpHelper = {
           height: process.env['chimp.phantom_h']?parseInt(process.env['chimp.phantom_h']):1024
         });
       }
-
-      runHook('webdriverio', 'setup', browser);
     };
 
     var addServerExecute = function () {

--- a/src/lib/chimp-helper.js
+++ b/src/lib/chimp-helper.js
@@ -15,6 +15,7 @@ var chai            = require('chai'),
     exit            = require('exit'),
     booleanHelper   = require('./boolean-helper');
 import merge from 'deep-extend';
+import runHook from './utils/run-hook';
 import {
   parseNullableString,
   parseNullableInteger,
@@ -67,7 +68,6 @@ var chimpHelper = {
   },
 
   setupBrowserAndDDP: function () {
-
     var setupBrowser = function () {
       log.debug('[chimp][helper] getting browser');
 
@@ -135,6 +135,8 @@ var chimpHelper = {
           height: process.env['chimp.phantom_h']?parseInt(process.env['chimp.phantom_h']):1024
         });
       }
+
+      runHook('webdriverio', 'setup', browser);
     };
 
     var addServerExecute = function () {

--- a/src/lib/chimp-helper.js
+++ b/src/lib/chimp-helper.js
@@ -67,6 +67,7 @@ var chimpHelper = {
   },
 
   setupBrowserAndDDP: function () {
+
     var setupBrowser = function () {
       log.debug('[chimp][helper] getting browser');
 

--- a/src/lib/jasmine/jasmine-helpers.js
+++ b/src/lib/jasmine/jasmine-helpers.js
@@ -1,10 +1,12 @@
 import chimpHelper from '../chimp-helper';
 import log from '../log';
+import runHook from '../utils/run-hook';
 
 beforeAll(function chimpSetup() {
   jasmine.DEFAULT_TIMEOUT_INTERVAL = 60000;
   chimpHelper.init();
   chimpHelper.setupBrowserAndDDP();
+  runHook('webdriverio', 'setup', browser);
 });
 
 afterAll(function chimpTeardown() {
@@ -13,4 +15,6 @@ afterAll(function chimpTeardown() {
     global.wrapAsync(global.sessionManager.killCurrentSession, global.sessionManager)();
     log.debug('[chimp][jasmine-helpers] Ended browser sessions');
   }
+
+  runHook('webdriverio', 'teardown', browser);
 });

--- a/src/lib/jasmine/jasmine-wrapper.js
+++ b/src/lib/jasmine/jasmine-wrapper.js
@@ -5,6 +5,7 @@ import Fiber from 'fibers';
 import _ from 'underscore';
 import {parseBoolean, parseString } from '../environment-variable-parsers';
 import escapeRegExp from '../utils/escape-reg-exp';
+import runHook from '../utils/run-hook';
 import fiberizeJasmineApi from './jasmine-fiberized-api';
 
 new Fiber(function runJasmineInFiber() {
@@ -38,6 +39,7 @@ new Fiber(function runJasmineInFiber() {
   jasmine.configureDefaultReporter(
     JSON.parse(process.env['chimp.jasmineReporterConfig'])
   );
+  runHook('jasmine', 'setup', jasmine);
   jasmine.execute();
 }).run();
 

--- a/src/lib/jasmine/jasmine-wrapper.js
+++ b/src/lib/jasmine/jasmine-wrapper.js
@@ -41,6 +41,7 @@ new Fiber(function runJasmineInFiber() {
   );
   runHook('jasmine', 'setup', jasmine);
   jasmine.execute();
+  runHook('jasmine', 'teardown', jasmine);
 }).run();
 
 

--- a/src/lib/mocha/mocha-helper.js
+++ b/src/lib/mocha/mocha-helper.js
@@ -1,12 +1,14 @@
 var chimpHelper = require('../chimp-helper');
 var exit = require('exit');
 var log = require('../log');
+import runHook from '../utils/run-hook';
 
 before(function () {
   process.env['chimp.chai'] = true;
   chimpHelper.loadAssertionLibrary();
   chimpHelper.init();
   chimpHelper.setupBrowserAndDDP();
+  runHook('webdriverio', 'setup', browser);
 });
 
 after(function () {
@@ -15,4 +17,6 @@ after(function () {
     global.wrapAsync(global.sessionManager.killCurrentSession, global.sessionManager)();
     log.debug('[chimp][mocha-helper] Ended browser sessions');
   }
+
+  runHook('webdriverio', 'teardown', browser);
 });

--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -9,6 +9,7 @@ var Mocha = require('mocha'),
 
 import {parseBoolean, parseString } from '../environment-variable-parsers';
 import escapeRegExp from '../utils/escape-reg-exp';
+import runHook from '../utils/run-hook';
 
 var mochaOptions = {
   ui: 'fiberized-bdd-ui',
@@ -37,8 +38,12 @@ glob.sync(path.join(testDir, '**')).filter(function (file) {
 });
 
 try {
-// Run the tests.
+  // Run the setup hook if it exits
+  runHook('mocha', 'setup', mocha);
+
+  // Run the tests.
   mocha.run(function (failures) {
+    runHook('mocha', 'teardown', mocha);
     exit(failures);
   });
 } catch (e) {

--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -38,7 +38,6 @@ glob.sync(path.join(testDir, '**')).filter(function (file) {
 });
 
 try {
-  // Run the setup hook if it exits
   runHook('mocha', 'setup', mocha);
 
   // Run the tests.

--- a/src/lib/utils/run-hook.js
+++ b/src/lib/utils/run-hook.js
@@ -1,0 +1,23 @@
+import path from 'path';
+import log from './../log';
+
+export default function runHook(module, method, ...args) {
+  const modulePath = process.env[`chimp.${module}Hooks`];
+  if (!modulePath) {
+    return;
+  }
+
+  let hooksModule = null;
+  try {
+    hooksModule = require(path.join(process.cwd(), modulePath));
+  } catch (e) {
+    log.error(`Could not find ${module}Hooks module at ${modulePath}`);
+    throw e;
+  }
+
+  const hook = hooksModule[method];
+  if (hook) {
+    log.debug(`[chimp][helper] running ${module} ${method} hook`);
+    hook(...args);
+  }
+}


### PR DESCRIPTION
I've been working to integrate chimp with appium, but there was a piece missing.  I needed to wire up custom methods for webdriverio, but I prefer to configure things like global jasmine behavior and extensions for webdriverio outside of the spec files.  I also discovered, as in #363, that jasmine and mocha instances aren't exposed globally, which means I couldn't set the onComplete event to guarantee webdriver would disconnect since I would otherwise have to kill my appium server or wait for the existing session to timeout.

This patch looks at the chimp config for the following hook modules:
* webdriverioHooks
* jasmineHooks
* mochaHooks

A hook module is define like this:
```
/** hooks/webdriverio.js */

export function setup(browser) {
  browser.addMethod('elementByAccessibilityId', function (id) {
    return browser.element(`~${id}`);
  });
}

export function teardown(browser) {
  // Do something with the browser instance before tests exit
}
```

The setup and teardown function could have an arbitrary number of args, but this guarantees an instance when you want it available for configuration.   This is working for me in Jasmine, but I haven't been able to test out Mocha yet.