### PR TITLE
Grep tests by custom mocha tags even when watch is disabled

### DIFF
--- a/src/bin/default.js
+++ b/src/bin/default.js
@@ -70,7 +70,7 @@ module.exports = {
   // - - - - MOCHA  - - - -
   mocha: false,
   // mochaTags only works when watch is false (disabled)
-  // mochaTags: ''
+  mochaTags: '',
   // 'path: './tests',
   mochaTimeout: 60000,
   mochaReporter: 'spec',

--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -21,6 +21,10 @@ if (parseBoolean(process.env['chimp.watch'])) {
   mochaOptions.grep = new RegExp(
     parseString(process.env['chimp.watchTags']).split(',').map(escapeRegExp).join('|')
   );
+} else {
+  mochaOptions.grep = new RegExp(
+    parseString(process.env['chimp.mochaTags']).split(',').map(escapeRegExp).join('|')
+  );
 }
 
 var mocha = new Mocha(mochaOptions);


### PR DESCRIPTION
The way the current setup is we can't leverage from the grep functionality Mocha provides, http://mochajs.org/#grep; Unless we use watch functionality. Hence adding the capability to choose tests from command line by tags. E.g. the following command will run tests that are tagged as `@smoke` only.

`chimp test/functional/chimp.js --path=test/functional --mocha --mochaTags='@smoke'`

`watchTags` still takes precedence over `mochaTags` and works as described in the documentation when watch is `true`. Once this is accepted I can update the docs as well. Please advise the best path.