### PR TITLE
Added the ability to turn off SSL validation for PhantomJS

### DIFF
--- a/dist/bin/default.js
+++ b/dist/bin/default.js
@@ -101,6 +101,7 @@ module.exports = {
   // - - - - PHANTOM  - - - -
   phantom_w: 1280,
   phantom_h: 1024,
+  phantom_ignoreSSLErrors: false,
 
   // - - - - DEBUGGING  - - - -
   log: 'info',

--- a/dist/lib/phantom.js
+++ b/dist/lib/phantom.js
@@ -33,6 +33,7 @@ function Phantom(options) {
 Phantom.prototype.start = function (callback) {
   var self = this;
   var port = self.options.port;
+  var ignoreSSLErrors = self.options.phantom_ignoreSSLErrors || 'false';
 
   if (this.child) {
     callback();
@@ -42,7 +43,7 @@ Phantom.prototype.start = function (callback) {
   this.child = processHelper.start({
     bin: phantomjs.path,
     prefix: 'phantom',
-    args: ['--webdriver', port],
+    args: ['--webdriver', port, '--ignore-ssl-errors', ignoreSSLErrors],
     waitForMessage: /GhostDriver - Main - running on port/,
     errorMessage: /Error/
   }, callback);


### PR DESCRIPTION
For localhost development, our project requires SSL and self-signed certs. Added the ability to pass the --ignore-ssl-errors flag to phantomjs