### PR TITLE
Add optional `phantom_path` to override PhantomJS with a local install

### DIFF
--- a/dist/lib/phantom.js
+++ b/dist/lib/phantom.js
@@ -41,7 +41,7 @@ Phantom.prototype.start = function (callback) {
   }
 
   this.child = processHelper.start({
-    bin: phantomjs.path,
+    bin: process.env['chimp.phantom_path'] || phantomjs.path,
     prefix: 'phantom',
     args: ['--webdriver', port, '--ignore-ssl-errors', ignoreSSLErrors],
     waitForMessage: /GhostDriver - Main - running on port/,

--- a/src/lib/phantom.js
+++ b/src/lib/phantom.js
@@ -38,7 +38,7 @@ Phantom.prototype.start = function (callback) {
   }
 
   this.child = processHelper.start({
-    bin: phantomjs.path,
+    bin: process.env['chimp.phantom_path'] || phantomjs.path,
     prefix: 'phantom',
     args: ['--webdriver', port],
     waitForMessage: /GhostDriver - Main - running on port/,


### PR DESCRIPTION
Workaround for issues where users want to be able to use a version of PhantomJS other than 1.9.8.

This pull request stems from an issue I had with 1.9.8. I have some tests written around functionality that calls `.bind(this)` on a function. `bind` wasn't supported in phantom until v2.0. Using a newer version of phantom also fixes some rendering problems that caused issues with calling `waitForExists` on certain selectors in the app. 

Installing locally and pointing chimp to that path as opposed to the one provided by `phantomjs-bin` was most appropriate.