### PR TITLE
allow seleniumStandaloneOptions.seleniumArgs to be set - fixes #428

### DIFF
--- a/src/__tests__/selenium-spec.js
+++ b/src/__tests__/selenium-spec.js
@@ -137,6 +137,26 @@ describe('Selenium', function () {
       expect(seleniumStandalone.start.mock.calls[0][0].seleniumArgs).toEqual(['-port', port]);
     });
 
+    it('retains pre-existing options.seleniumArgs when starting selenium', function () {
+      var Selenium = require('../lib/selenium');
+      var port = '4444';
+      var opt = '-some-option=True';
+      var selenium = new Selenium({
+        port,
+        seleniumStandaloneOptions: {seleniumArgs: [opt]},
+      });
+      var seleniumStandalone = require('selenium-standalone');
+      selenium.install = jest.genMockFunction();
+      selenium.install.mockImplementation(function (callback) {
+        callback(null);
+      });
+
+      var callback = function () {};
+      selenium.start(callback);
+
+      expect(seleniumStandalone.start.mock.calls[0][0].seleniumArgs).toEqual([opt, '-port', port]);
+    });
+
     it('sets this.child to the selenium child process', function () {
       var Selenium = require('../lib/selenium');
       var selenium = new Selenium({

--- a/src/lib/selenium.js
+++ b/src/lib/selenium.js
@@ -108,7 +108,8 @@ Selenium.prototype.start = function (callback) {
       return;
     }
 
-    self.seleniumStandaloneOptions.seleniumArgs = ['-port', port];
+    const seleniumArgs = self.seleniumStandaloneOptions.seleniumArgs || [];
+    self.seleniumStandaloneOptions.seleniumArgs = seleniumArgs.concat('-port', port);
 
     if (process.env['chimp.log'] === 'verbose' || process.env['chimp.log'] === 'debug') {
       self.options.seleniumDebug = true;

--- a/src/lib/selenium.js
+++ b/src/lib/selenium.js
@@ -108,8 +108,10 @@ Selenium.prototype.start = function (callback) {
       return;
     }
 
-    const seleniumArgs = self.seleniumStandaloneOptions.seleniumArgs || [];
-    self.seleniumStandaloneOptions.seleniumArgs = seleniumArgs.concat('-port', port);
+    if (!self.seleniumStandaloneOptions.seleniumArgs) {
+      self.seleniumStandaloneOptions.seleniumArgs = [];
+    }
+    self.seleniumStandaloneOptions.seleniumArgs.push('-port', port);
 
     if (process.env['chimp.log'] === 'verbose' || process.env['chimp.log'] === 'debug') {
       self.options.seleniumDebug = true;


### PR DESCRIPTION
Change allows `seleniumStandaloneOptions.seleniumArgs` to be set so other args, besides the port, can be passed to selenium on start. Fixes #428 by allowing chrome driver options to be set. Includes a test.

This change could be handy in various use-cases, not just the one outlined in #428.