### PR TITLE
Update fibers - support for Node v6.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "cucumber": "xolvio/cucumber-js#v1.2.2-chimp",
     "deep-extend": "^0.4.1",
     "exit": "^0.1.2",
-    "fibers": "^1.0.13",
+    "fibers": "^1.0.14",
     "freeport": "~1.0.5",
     "fs-extra": "~0.30.0",
     "glob": "^6.0.1",


### PR DESCRIPTION
Support for Node.js v6.5.0.

See
* https://github.com/laverdet/node-fibers/issues/304
* https://github.com/laverdet/node-fibers/issues/306