### PR TITLE
Use a valid base64 image/png encoding

### DIFF
--- a/src/lib/cucumberjs/hooks.js
+++ b/src/lib/cucumberjs/hooks.js
@@ -71,7 +71,7 @@ module.exports = function hooks() {
    */
   this.After((scenario) => { // eslint-disable-line new-cap
     _.each(screenshots, (element) => {
-      const decodedImage = new Buffer(element.png, 'base64').toString('binary');
+      const decodedImage = new Buffer(element.png, 'base64');
       scenario.attach(decodedImage, 'image/png');
     });
   });


### PR DESCRIPTION
When attaching screenshots to a scenario (fixes #462).