### PR TITLE
Make Community links explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/chimp/backer/29/website" target="_blank"><img src="https://opencollective.com/chimp/backer/29/avatar.svg"></a>
 
 ## Community
-**Slack:** Join our Slack xolv.io/community #chimp channel, where you can find help and help others.
+**Slack:** Join our Slack [xolv.io/community](http://community.xolv.io) #chimp channel, where you can find help and help others.
 
 **Gitter:** https://gitter.im/xolvio/chimp
 

--- a/README.md
+++ b/README.md
@@ -182,6 +182,7 @@ Support us with a monthly donation and help us continue our activities. [[Become
 
 ## Community
 **Slack:** Join our Slack xolv.io/community #chimp channel, where you can find help and help others.
+
 **Gitter:** https://gitter.im/xolvio/chimp
 
 ## Sponsors

--- a/README.md
+++ b/README.md
@@ -218,3 +218,5 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 <a href="https://opencollective.com/chimp/sponsor/27/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/27/avatar.svg"></a>
 <a href="https://opencollective.com/chimp/sponsor/28/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/28/avatar.svg"></a>
 <a href="https://opencollective.com/chimp/sponsor/29/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/29/avatar.svg"></a>
+
+

--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ Support us with a monthly donation and help us continue our activities. [[Become
 <a href="https://opencollective.com/chimp/backer/28/website" target="_blank"><img src="https://opencollective.com/chimp/backer/28/avatar.svg"></a>
 <a href="https://opencollective.com/chimp/backer/29/website" target="_blank"><img src="https://opencollective.com/chimp/backer/29/avatar.svg"></a>
 
+## Community
+**Slack:** Join our Slack xolv.io/community #chimp channel, where you can find help and help others.
+**Gitter:** https://gitter.im/xolvio/chimp
 
 ## Sponsors
 
@@ -215,5 +218,3 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 <a href="https://opencollective.com/chimp/sponsor/27/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/27/avatar.svg"></a>
 <a href="https://opencollective.com/chimp/sponsor/28/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/28/avatar.svg"></a>
 <a href="https://opencollective.com/chimp/sponsor/29/website" target="_blank"><img src="https://opencollective.com/chimp/sponsor/29/avatar.svg"></a>
-
-


### PR DESCRIPTION
## Make Community links explicit

Gitter and slack links are not explicit. The badges on the top are getting lost among the other badges
