### PR TITLE
add geckodriver to seleniumstandaloneoptions

### DIFF
--- a/src/bin/default.js
+++ b/src/bin/default.js
@@ -82,6 +82,13 @@ module.exports = {
         version: '2.50.0',
         arch: 'ia32',
         baseURL: 'https://selenium-release.storage.googleapis.com'
+      },
+     firefox: {
+        // check for more recent versions of gecko  driver here:
+        // https://github.com/mozilla/geckodriver/releases
+        version: '0.11.1',
+        arch: process.arch,
+        baseURL: 'https://github.com/mozilla/geckodriver/releases/download'
       }
     }
   },

--- a/src/bin/default.js
+++ b/src/bin/default.js
@@ -83,7 +83,7 @@ module.exports = {
         arch: 'ia32',
         baseURL: 'https://selenium-release.storage.googleapis.com'
       },
-     firefox: {
+      firefox: {
         // check for more recent versions of gecko  driver here:
         // https://github.com/mozilla/geckodriver/releases
         version: '0.11.1',


### PR DESCRIPTION
See https://github.com/vvo/selenium-standalone/commit/e3cfd25255e8cabdf0a8e0ee89b03085112e57d6

Adds config options so that you can run tests in firefox versions that use marionette
