### PR TITLE
Increase chromedriver version to 2.25.

### DIFF
--- a/src/bin/default.js
+++ b/src/bin/default.js
@@ -72,7 +72,7 @@ module.exports = {
       chrome: {
         // check for more recent versions of chrome driver here:
         // http://chromedriver.storage.googleapis.com/index.html
-        version: '2.24',
+        version: '2.25',
         arch: process.arch,
         baseURL: 'https://chromedriver.storage.googleapis.com'
       },


### PR DESCRIPTION
Increase chromedriver to 2.25 (10/25/16 release) - fixes "Chromedriver crashes during event Runtime.consoleAPICalled" errors which result in test suite failures. 
Issues:
https://github.com/xolvio/chimp/issues/516
https://bugs.chromium.org/p/chromedriver/issues/detail?id=1547

CircleCI build with increased version:
https://circleci.com/gh/kyleian/chimp/2