### PR TITLE
mention mocha config breaking change in history.md; fallback to mochaXYZ if present

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -2,6 +2,7 @@
 
 * Improvement/offline detection (#535) (Sam Hatoum) 
 * Improvement/custom mocha options (#534) (Sam Hatoum) 
+  - **Breaking change:** the old mochaXYZ options are not read, put mocha config in mochConfig {} object as in https://github.com/xolvio/chimp/blob/master/src/bin/default.js 
 * Improvement/chrome driver mode (#533) (Sam Hatoum) 
 
 # 0.43.0


### PR DESCRIPTION
#534 uses updated mocha config which breaks old config. 

**TODO**
- [x] mention mocha config breaking change in history.md; fixes #538 
- [ ] (optional) fallback to mochaXYZ options if detected. Please let me know if you'd like/accept this and I can provide a PR for this

PS: Also, I've a feeling you auto-generate your HISTORY.md, if so, I'd guess you'd want to keep manual edits out of it. Please let me know an alternative way to mention this change in that case :)