### PR TITLE
Fixes received error null when using hub-cloud.browserstack.com hostname

### DIFF
--- a/src/lib/browserstack-manager.js
+++ b/src/lib/browserstack-manager.js
@@ -11,7 +11,7 @@ function BrowserStackSessionManager(options) {
 
   log.debug('[chimp][browserstack-session-manager] options are', options);
 
-  var host = options.host.replace('hub.', 'www.');
+  var host = options.host.replace(/hub\.|hub-cloud\./, 'www.');
   var browserStackBaseUrl = 'https://' + options.user + ':' + options.key + '@' + host;
   options.browserStackUrl = browserStackBaseUrl;
 


### PR DESCRIPTION
Fixes #530 