### PR TITLE
Fixes mochaCommandLineOptions CLI parameter

### DIFF
--- a/src/bin/default.js
+++ b/src/bin/default.js
@@ -104,7 +104,6 @@ module.exports = {
 
   // - - - - MOCHA  - - - -
   mocha: false,
-  mochaCommandLineOptions: ['--color'],
   mochaConfig: {
     // tags and grep only work when watch mode is false
     tags: '',
@@ -112,6 +111,7 @@ module.exports = {
     timeout: 60000,
     reporter: 'spec',
     slow: 10000,
+    useColors: true
   },
 
   // - - - - JASMINE  - - - -

--- a/src/lib/mocha/mocha-wrapper.js
+++ b/src/lib/mocha/mocha-wrapper.js
@@ -5,12 +5,20 @@ var Mocha = require('mocha'),
   path = require('path'),
   exit = require('exit'),
   glob = require('glob'),
-  ui = require('./mocha-fiberized-ui');
+  ui = require('./mocha-fiberized-ui'),
+    _ = require('underscore');
 
 import {parseBoolean, parseNullableString, parseString} from '../environment-variable-parsers';
 import escapeRegExp from '../utils/escape-reg-exp';
 
   var mochaConfig = JSON.parse(process.env.mochaConfig);
+
+const mochaCommandLineOptions = process.env['chimp.mochaCommandLineOptions'] ? JSON.parse(process.env['chimp.mochaCommandLineOptions']) : false;
+
+if (mochaCommandLineOptions && _.isObject(mochaCommandLineOptions)) {
+  _.extend(mochaConfig, mochaCommandLineOptions);
+}
+
 mochaConfig.ui = 'fiberized-bdd-ui';
 
 if (!mochaConfig.grep && parseBoolean(process.env['chimp.watch'])) {
@@ -25,8 +33,8 @@ var mocha = new Mocha(mochaConfig);
 
 mocha.addFile(path.join(path.resolve(__dirname, path.join('mocha-helper.js'))));
 
-if (process.argv.length > 3) {
-  process.argv.splice(3).forEach(function (spec) {
+if (process.argv.length > 2) {
+  process.argv.splice(2).forEach(function (spec) {
     mocha.addFile(spec);
   });
 } else {

--- a/src/lib/mocha/mocha.js
+++ b/src/lib/mocha/mocha.js
@@ -69,11 +69,7 @@ Mocha.prototype.start = function (callback) {
   opts.env = _.extend(process.env, {
     mochaConfig: JSON.stringify(this.options.mochaConfig)
   });
-
-  self.child = cp.fork(path.join(__dirname, 'mocha-wrapper.js'), _.union(
-    this.options.mochaCommandLineOptions,
-    _specs
-  ), opts);
+  self.child = cp.fork(path.join(__dirname, 'mocha-wrapper.js'), _specs, opts);
 
   self.child.stdout.pipe(process.stdout);
   self.child.stderr.pipe(process.stderr);


### PR DESCRIPTION
Fixes #529 

Usage: `chimp --mocha --mochaCommandLineOptions '{ "bail": true }'`