### PR TITLE
Check for errors from BrowserStack API on killCurrentSession

### DIFF
--- a/src/lib/browserstack-manager.js
+++ b/src/lib/browserstack-manager.js
@@ -94,14 +94,14 @@ BrowserStackSessionManager.prototype.killCurrentSession = function (callback) {
 
   this._getBuilds(function (err, builds) {
     if (err) {
-      log.error('[chimp][browserstack-session-manager]', 'received getBuilds error', err);
+      log.error('[chimp][browserstack-session-manager]', 'received getBuilds error');
       callback(err);
     } else {
       if (builds && builds.length) {
         log.debug('[chimp][browserstack-session-manager]', builds, builds[0]);
         var buildId = builds[0].automation_build.hashed_id;
       }
-      if (buildId !== undefined && buildId !== '') {
+      if (buildId) {
         this._getSessions(buildId, function (err, sessions) {
           if (sessions && sessions.length) {
             var options = {


### PR DESCRIPTION
In my own usage of Chimp + Bamboo CI + BrowserStack, I've been seeing rare failures that I believe are related to this chunk of code. From time to time, the builds data that comes back is just an empty array which fails the `buildId !== ""` logic since `buildId` is actually `undefined`, not an empty string.