### PR TITLE
Fixes Cucumber Failure output

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "chromedriver": "^2.27.2",
     "colors": "1.1.2",
     "commander": "^2.9.0",
-    "cucumber": "xolvio/cucumber-js#v1.3.0-chimp.2",
+    "cucumber": "xolvio/cucumber-js#v1.3.0-chimp.3",
     "deep-extend": "^0.4.1",
     "exit": "^0.1.2",
     "fibers": "^1.0.14",


### PR DESCRIPTION
Blocks Gherkin version at 4.0.0 in xolvio/cucumber-js to restore failure summary in Cucubmer.