### PR TITLE
lib/cucumberjs: catch runtime errors

### DIFF
--- a/src/lib/cucumberjs/cucumber-wrapper.js
+++ b/src/lib/cucumberjs/cucumber-wrapper.js
@@ -70,7 +70,12 @@ function Cli(argv) {
       formatters.forEach(function (formatter) {
         runtime.attachListener(formatter);
       });
-      runtime.start(callback);
+      try {
+        runtime.start(callback);
+      } catch (e) {
+        console.log(e.stack || e)
+        callback(false)
+      }
     }
   };
   return self;

--- a/src/lib/cucumberjs/cucumber.js
+++ b/src/lib/cucumberjs/cucumber.js
@@ -95,7 +95,7 @@ class Cucumber {
         }
 
         const failWhenNoTestsRun = booleanHelper.isTruthy(this.options['fail-when-no-tests-run']);
-        const noTestsFound = JSON.parse(jsonResults).length === 0;
+        const noTestsFound = jsonResults === null || JSON.parse(jsonResults).length === 0;
 
         callback(code !== 0 || (code === 0 && noTestsFound && failWhenNoTestsRun) ? 'Cucumber steps failed' : null, jsonResults);
       }


### PR DESCRIPTION
This makes running tests in watch mode a bit smoother. Before running our e2e tests we spin up a `webpack-dev-server` and a few docker containers and then start the chimp test suites. This bootstrap process takes a while.

When running tests in watch mode and inadvertently causing the cucumber runtime to error out (e.g. via syntax error in a step file) the error goes unhandled and the chimp process dies. When this happens, often while writing new tests in watch mode, we have to re-do the bootstrap process. This PR makes it possible to catch these errors and handle them, e.g.:

```js
do {
    try {
        // startChimp is a custom Promisified wrapper around chimp.init()
        await startChimp(chimpConfig)
    } catch (e) {
        if (!chimpConfig.watch) { throw e }
    }
} while (chimpConfig.watch)
```