### PR TITLE
Fixed issue in session-manager where "noSessionReuse" option was not properly read

### DIFF
--- a/src/lib/session-manager.js
+++ b/src/lib/session-manager.js
@@ -240,7 +240,7 @@ SessionManager.prototype.killCurrentSession = function (callback) {
     return;
   }
 
-  if (!process.env['chimp.noSessionReuse']) {
+  if (booleanHelper.isTruthy(process.env['chimp.noSessionReuse'])) {
     log.debug('[chimp][session-manager] noSessionReuse is true, , not killing session');
     callback();
     return;


### PR DESCRIPTION
The option `noSessionReuse` dit not work. In the beginning of a run the following debug is printed:
```
[chimp][session-manager] noSessionReuse is true, not reusing a session
```

But then it deletes all sessions anyway.
This pull request uses the same logic for that first line in the code where it actually deletes sessions.