### PR TITLE
Check for existence of this.options._ before checking length

### DIFF
--- a/src/lib/mocha/mocha.js
+++ b/src/lib/mocha/mocha.js
@@ -87,7 +87,7 @@ Mocha.prototype.start = function (callback) {
   }
 
   let _specs = [];
-  if (this.options._.length > 2) {
+  if (this.options._ && this.options._.length > 2) {
     _specs = this.options._.slice(2);
   }
 


### PR DESCRIPTION
`this.options._` contains command line arguments so when using the chimp library through a script this throws an error since there aren't any arguments

```
/demo/node_modules/chimp/dist/lib/mocha/mocha.js:79
  if (this.options._.length > 2) {
```