### PR TITLE
Enable minor updates to chromedriver to support chrome 65

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "chai-as-promised": "^6.0.0",
     "child-process-debug": "0.0.7",
     "chokidar": "~1.6.0",
-    "chromedriver": "~2.35",
+    "chromedriver": "^2.35",
     "colors": "1.1.2",
     "commander": "^2.9.0",
     "cucumber": "xolvio/cucumber-js#v1.3.0-chimp.6",


### PR DESCRIPTION
Right now chimp tests fail on Chrome 65 which requires chromedriver >= 2.36. More info [here](https://sites.google.com/a/chromium.org/chromedriver/downloads) (chromedriver download page)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/xolvio/chimp/681)
<!-- Reviewable:end -->
