### PR TITLE
fix: use the version of pascal-case that comes with chimp, 

### DIFF
--- a/lib/reexports.js
+++ b/lib/reexports.js
@@ -1,0 +1,3 @@
+const { pascalCase } = require('pascal-case');
+
+module.exports = { pascalCase };

--- a/templates/getCodegenConfig.js
+++ b/templates/getCodegenConfig.js
@@ -1,7 +1,7 @@
 const fs = require("fs");
+const { pascalCase } = require("chimp/lib/reexports");
 const { importSchema } = require("graphql-import");
 const { isObjectType } = require("graphql");
-const { pascalCase } = require("pascal-case");
 
 let schemaString = fs
   .readFileSync("./schema.graphql")


### PR DESCRIPTION
because the old one did not have a named export, and if a project already dependend on the old version of pascal-case chimp won't work