### PR TITLE
feat: derived types from function

### DIFF
--- a/src/generate/templates/typeTypeResolvers.spec.handlebars
+++ b/src/generate/templates/typeTypeResolvers.spec.handlebars
@@ -1,14 +1,14 @@
 import td from "testdouble";
-import { GqlContext, ParentType, test{{typeName}}{{capitalizedFieldName}} {{#if hasArguments}},{{pascalCasedArgName}}{{/if}} } from "{{generatedPrefix}}/graphql/helpers/{{typeName}}{{capitalizedFieldName}}SpecWrapper"
+import { GqlContext, ParentType, test{{typeName}}{{capitalizedFieldName}} {{#if hasArguments}},ArgsType{{/if}} } from "{{generatedPrefix}}/graphql/helpers/{{typeName}}{{capitalizedFieldName}}SpecWrapper"
 
 test("{{typeName}}{{capitalizedFieldName}}", async () => {
 const context = td.object<GqlContext>();
     // td.when(context.{{moduleName}}Repository.findOne()).thenResolve()
     // const parent: ParentType = {}
     {{#if hasArguments}}
-        // const variables: {{pascalCasedArgName}} = {}
+        // const args: ArgsType = {}
     {{/if}}
 
-    // const result = await test{{typeName}}{{capitalizedFieldName}}(parent, {{#if hasArguments}}variables,{{/if}} context);
+    // const result = await test{{typeName}}{{capitalizedFieldName}}(parent, {{#if hasArguments}}args,{{/if}} context);
 
     });

--- a/src/generate/templates/typeTypeResolversSpecWrapper.handlebars
+++ b/src/generate/templates/typeTypeResolversSpecWrapper.handlebars
@@ -2,10 +2,14 @@ import { GraphQLResolveInfo } from 'graphql'
 import type { GqlContext, ResolversParentTypes, {{#if hasArguments}}{{pascalCasedArgName}}{{/if}} } from "{{generatedPrefix}}/graphql/types";
 import { {{typeName}}{{capitalizedFieldName}} } from "{{appPrefix}}/{{graphqlFileRootPath}}types/{{typeName}}{{capitalizedFieldName}}";
 
+type Params = Parameters<NonNullable<typeof {{typeName}}{{capitalizedFieldName}}>>
 {{#if resolveReferenceType}}type ParentType = Parameters<NonNullable<typeof {{typeName}}{{capitalizedFieldName}}>>[0];{{else}}
-        type ParentType = ResolversParentTypes["{{typeName}}"]
+type ParentType = Params[0]
+{{/if}}
+{{#if hasArguments}}
+type ArgsType = Params[1]
 {{/if}}
 
-    export const test{{typeName}}{{capitalizedFieldName}} = (parent: ParentType, {{#if hasArguments}}variables: {{pascalCasedArgName}},{{/if}} context: GqlContext) => {{typeName}}{{capitalizedFieldName}}?.({...parent, {{#if isFederatedAndExternal}}__typename: '{{typeName}}'{{/if}} }, {{#unless resolveReferenceType}}{{#if hasArguments}}variables{{else}} {} {{/if}},{{/unless}} context, {} as GraphQLResolveInfo)
+    export const test{{typeName}}{{capitalizedFieldName}} = (parent: ParentType, {{#if hasArguments}}args: ArgsType,{{/if}} context: GqlContext) => {{typeName}}{{capitalizedFieldName}}?.({...parent, {{#if isFederatedAndExternal}}__typename: '{{typeName}}'{{/if}} }, {{#unless resolveReferenceType}}{{#if hasArguments}}args{{else}} {} {{/if}},{{/unless}} context, {} as GraphQLResolveInfo)
 
-    export type {GqlContext, ParentType, ResolversParentTypes {{#if hasArguments}},{{pascalCasedArgName}}{{/if}} }
+    export type {GqlContext, ParentType, ResolversParentTypes {{#if hasArguments}}, ArgsType, {{pascalCasedArgName}}{{/if}} }


### PR DESCRIPTION
- this is to fix the issue where the args/variable types do not match when the schema defined the args as optional.
- rename variable name to match the one generated in resolvers.