### PR TITLE
fix: upgrades typescript version

### DIFF
--- a/scaffold/package.json
+++ b/scaffold/package.json
@@ -68,6 +68,6 @@
     "testdouble-jest": "2.0.0",
     "ts-jest": "26.1.3",
     "ts-node": "8.10.2",
-    "typescript": "3.9.7"
+    "typescript": "4.7.4"
   }
 }


### PR DESCRIPTION
Upgrading typescript version as end-to-end test was failing while running the type check with below error: 

`
 > graphql-scaffold@1.0.0 type-check /home/runner/work/chimp/chimp-test-repo
  > tsc --noEmit
  Error: node_modules/@types/prettier/index.d.ts(41,54): error TS2315: Type 'IsTuple' is not generic.
  Error: node_modules/@types/prettier/index.d.ts(53,6): error TS2456: Type alias 'IsTuple' circularly references itself.
  Error: node_modules/@types/prettier/index.d.ts(53,65): error TS2574: A rest element type must be an array type.
  Error: node_modules/@types/prettier/index.d.ts(53,84): error TS2315: Type 'IsTuple' is not generic.
  Error: node_modules/@types/prettier/index.d.ts(96,5): error TS2589: Type instantiation is excessively deep and possibly infinite.
  Error: node_modules/@types/prettier/index.d.ts(131,5): error TS2589: Type instantiation is excessively deep and possibly infinite.
  Error: node_modules/@types/prettier/index.d.ts(165,5): error TS2589: Type instantiation is excessively deep and possibly infinite.
`

